### PR TITLE
Fix cameras with weird boundaries & support digest auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ The script is designed to be simple to use with minimal configuration. All video
 2. Ensure submodules are correctly installed by running `git submodule update --init`
 
 # Usage
-`relay.py [-p <relay port>] [-w <WebSocket port>] [-q] stream-source-url`
+`relay.py [-p <relay port>] [-w <WebSocket port>] [-q] [-d] stream-source-url`
 
 - **-p \<relay port\>**: Port that the stream will be relayed on (default is 54321)
 - **-w \<WebSocket port\>**: Port that the stream will be relayed on via WebSockets (default is 54322)
 - **-q**: Silence non-essential output
+- **-d**: Turn debugging on
 - **stream-source-url**: URL of the existing MJPEG stream. If the stream is protected with HTTP authentication, supply the credentials via the URL like so: `http://user:password@ip:port/path/to/stream/`
 
 Once it is running, you can access the following URLs:

--- a/app/broadcaster.py
+++ b/app/broadcaster.py
@@ -170,7 +170,7 @@ class Broadcaster:
 		while True:
 			try:
 				for data in self.sourceStream.iter_content(1024):
-					if (self.kill == True):
+					if self.kill:
 						for client in self.clients + self.webSocketClients:
 							client.kill = True
 						return

--- a/app/broadcaster.py
+++ b/app/broadcaster.py
@@ -29,12 +29,10 @@ class Broadcaster:
 	_instance = None
 
 	def __init__(self, url):
-		self.headerType = "multipart/x-mixed-replace"
 		self.url = url
 
 		self.clients = []
 		self.webSocketClients = []
-		self.clientCount = 0
 
 		self.status = Status._instance
 

--- a/app/httprequesthandler.py
+++ b/app/httprequesthandler.py
@@ -101,7 +101,7 @@ class HTTPRequestHandler:
 		while True:
 			clientsock, addr = self.acceptsock.accept()
 
-			if (self.kill == True):
+			if self.kill:
 				clientsock.close()
 				return
 			handlethread = threading.Thread(target = self.handleRequest, args = (clientsock,))

--- a/relay.py
+++ b/relay.py
@@ -24,7 +24,7 @@ except ImportError, e:
 # Close threads gracefully
 #
 def quit():
-	broadcast.kill = True
+	broadcaster.kill = True
 	requestHandler.kill = True
 	quitsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	quitsock.connect(("127.0.0.1", options.port))

--- a/relay.py
+++ b/relay.py
@@ -37,6 +37,7 @@ if __name__ == '__main__':
 	op.add_option("-p", "--port", action="store", default = 54321, dest="port", help = "Port to serve the MJPEG stream on")
 	op.add_option("-w", "--ws-port", action="store", default = 54322, dest="wsport", help = "Port to serve the MJPEG stream on via WebSockets")
 	op.add_option("-q", "--quiet", action="store_true", default = False, dest="quiet", help = "Silence non-essential output")
+	op.add_option("-d", "--debug", action="store_true", default = False, dest="debug", help = "Turn debugging on")
 
 	(options, args) = op.parse_args()
 
@@ -46,6 +47,12 @@ if __name__ == '__main__':
 
 	logging.basicConfig(level=logging.WARNING if options.quiet else logging.INFO, format="%(message)s")
 	logging.getLogger("requests").setLevel(logging.WARNING if options.quiet else logging.INFO)
+
+	if options.debug:
+		from httplib import HTTPConnection
+		HTTPConnection.debuglevel = 1
+		logging.getLogger().setLevel(logging.DEBUG)
+		logging.getLogger("requests").setLevel(logging.DEBUG)
 
 	try:
 		options.port = int(options.port)


### PR DESCRIPTION
Hello, this should fix #12 

The main changes are:

- Fix for weird boundaries returned by some cameras. Also a bit of refactoring by removing the `boundarySeparatorPrefix` variable which did not seem useful. Basically some cameras return the boundary as `--myboundary` and others as `boundary`, the patch simply adds `--` if needed.
- Add ability to debug requests with `-d, --debug` to see what's going on.
- Support HTTP digest auth for newer cameras, by trying basic auth first and then digest auth if that fails.
- Fix a typo that throwed an exception everytime when we quitted.