### PR TITLE
Better shutdown

### DIFF
--- a/app/broadcaster.py
+++ b/app/broadcaster.py
@@ -36,7 +36,6 @@ class Broadcaster:
 
 		self.status = Status._instance
 
-		self.kill = False
 		self.broadcastThread = threading.Thread(target = self.streamFromSource)
 		self.broadcastThread.daemon = True
 
@@ -65,6 +64,10 @@ class Broadcaster:
 			self.broadcasting = True
 			logging.info("Connected to stream source, boundary separator: {}".format(self.boundarySeparator))
 			self.broadcastThread.start()
+
+	def stop(self):
+		for clients in self.clients + self.webSocketClients:
+			client.stop()
 
 	#
 	# Connects to the stream source
@@ -170,10 +173,6 @@ class Broadcaster:
 		while True:
 			try:
 				for data in self.sourceStream.iter_content(1024):
-					if self.kill:
-						for client in self.clients + self.webSocketClients:
-							client.kill = True
-						return
 					self.broadcast(data)
 					self.status.addToBytesIn(len(data))
 					self.status.addToBytesOut(len(data)*self.getClientCount())

--- a/app/httprequesthandler.py
+++ b/app/httprequesthandler.py
@@ -23,18 +23,19 @@ class HTTPRequestHandler:
 		self.acceptsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		self.acceptsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 		self.acceptsock.bind(("0.0.0.0", port))
-		self.acceptsock.listen(10)
 
 		self.broadcast = Broadcaster._instance
 		self.status = Status._instance
-
-		self.kill = False
 
 		self.acceptThread = threading.Thread(target = self.acceptClients)
 		self.acceptThread.daemon = True
 
 	def start(self):
+		self.acceptsock.listen(10)
 		self.acceptThread.start()
+
+	def stop(self):
+		self.acceptsock.close()
 
 	#
 	# Thread to process client requests
@@ -100,9 +101,5 @@ class HTTPRequestHandler:
 	def acceptClients(self):
 		while True:
 			clientsock, addr = self.acceptsock.accept()
-
-			if self.kill:
-				clientsock.close()
-				return
 			handlethread = threading.Thread(target = self.handleRequest, args = (clientsock,))
 			handlethread.start()

--- a/app/streaming.py
+++ b/app/streaming.py
@@ -19,7 +19,6 @@ class StreamingClient(object):
 		self.streamThread = threading.Thread(target = self.stream)
 		self.streamThread.daemon = True
 		self.connected = True
-		self.kill = False
 		super(StreamingClient, self).__init__()
 
 	def start(self):
@@ -40,9 +39,8 @@ class StreamingClient(object):
 			#this call blocks if there's no data in the queue, avoiding the need for busy-waiting
 			self.streamBuffer += self.streamQueue.get()
 
-			#check if kill or connected state has changed after being blocked
-			if (self.kill or not self.connected):
-				self.stop()
+			#check if connected state has changed after being blocked
+			if (not self.connected):
 				return
 
 			while (len(self.streamBuffer) > 0):

--- a/relay.py
+++ b/relay.py
@@ -24,11 +24,9 @@ except ImportError, e:
 # Close threads gracefully
 #
 def quit():
-	broadcaster.kill = True
-	requestHandler.kill = True
-	quitsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	quitsock.connect(("127.0.0.1", options.port))
-	quitsock.close()
+	broadcaster.stop()
+	requestHandler.stop()
+	webSocketServer.close()
 	sys.exit(1)
 
 if __name__ == '__main__':
@@ -73,8 +71,8 @@ if __name__ == '__main__':
 	requestHandler = HTTPRequestHandler(options.port)
 	requestHandler.start()
 
-	s = SimpleWebSocketServer('', options.wsport, WebSocketStreamingClient)
-	webSocketHandlerThread = threading.Thread(target=s.serveforever)
+	webSocketServer = SimpleWebSocketServer('', options.wsport, WebSocketStreamingClient)
+	webSocketHandlerThread = threading.Thread(target = webSocketServer.serveforever)
 	webSocketHandlerThread.daemon = True
 	webSocketHandlerThread.start()
 


### PR DESCRIPTION
Only the last commit is relevant here, as the others are from #13

I'll rebase this PR onces #13 is merged.

This basically removes all the `foo.kill`. It looks like "it works" but I didn't give it a lot of testing.

By the way, does https://github.com/Silex/mjpeg-relay/blob/217904d862cade494d031667d9e30884a9e1e34d/relay.py#L26 really make sense? I know it works, but theorically how can `quit()` access global variables here? I guess I don't know python enough :stuck_out_tongue_closed_eyes: 

I think it's simpler to move the quit() body at the bottom of the try block, and remove the quit() calls. There's no real need to have multiple exit paths.

I was thinking of refactoring a bit more and replacing the `foo.connected` thing with a function instead, that way we can get rid of the variable and the check is always accurate (simply return the socket state).

Also, each of these "servers" should have a saner start/stop mechanism. At the moment the thread thing for each of them is a bit weird... not the thread in itself but its permanence. I think in general, "start" should start listening/open the socket and spawn a thread, and stop should close the socket/server and kill the thread.

I'll see what I can do, and ping you when I have something. Give me your thoughts in the meantime :wink: 

p.s: you code on windows? I was a bit surprised by the windows line endings.