### PR TITLE
Use canvas in websocketexample.html

### DIFF
--- a/websocketexample.html
+++ b/websocketexample.html
@@ -2,78 +2,41 @@
 	<head>
 		<title>mjpeg-relay example</title>
 	</head>
-	<body onload="connectToStream()">
-		<script language="javascript" type="text/javascript">
+	<body>
+		<canvas id="canvas" width="350" height="225"></canvas>
 
+		<script>
 			//--CONFIGURATION--
 
 			var websocketAddress = "ws://localhost:54018";
-			var imageWidth = "350px";
-			var imageHeight = "225px";
 
 			//--END OF CONFIGURATION--
 
-			var frameBuffer = new Array();
-			var frameCount = 0;
+			var c = document.getElementById("canvas");
+			var ctx = c.getContext("2d");
 
-			function imageOnload()
-			{
-				//bring the new image to the top
-				this.style.zIndex = frameCount;
+			var websocket = new WebSocket(websocketAddress);
 
-				while (frameBuffer.length > 10)
-				{
-					//remove oldest frames, keeping a buffer of 10 most recent frames to avoid flickering
-					var oldFrame = frameBuffer.shift();
-					oldFrame.parentNode.removeChild(oldFrame);
-				}
+			websocket.onopen = function () {
+				console.log("mjpeg-relay connected");
+			};
 
-				frameBuffer.push(this);
-			}
+			websocket.onclose = function () {
+				console.log("mjpeg-relay disconnected");
+			};
 
-			function connectToStream()
-			{
-				websocket = new WebSocket(websocketAddress);
-				websocket.onopen = function(evt) { onOpen(evt) };
-				websocket.onclose = function(evt) { onClose(evt) };
-				websocket.onmessage = function(evt) { onMessage(evt) };
-				websocket.onerror = function(evt) { onError(evt) };
-			}
+			websocket.onmessage = function (evt) {
+				var image = new Image();
+				image.onload = function () {
+					ctx.drawImage(image, 0, 0);
+				};
+				image.src = evt.data;
+			};
 
-			function onOpen(evt)
-			{
-				console.log("mjpeg-relay connected\n");
-			}
-
-			function onClose(evt)
-			{
-				console.log("mjpeg-relay disconnected\n");
-			}
-
-			function onMessage(evt)
-			{
-				var newFrame = new Image();
-				newFrame.style.position = "absolute";
-				newFrame.style.zIndex = -1;
-				newFrame.style.height = imageHeight;
-				newFrame.style.width = imageWidth;
-
-				frameCount++;
-
-				newFrame.onload = imageOnload;
-				newFrame.src = evt.data;
-
-				var stream = document.getElementById("mjpeg-relay");
-				stream.insertBefore(newFrame, stream.firstChild);
-			}
-
-			function onError(evt)
-			{
-				console.log('error: ' + evt.data + '\n');
+			websocket.onerror = function (evt) {
+				console.log('error: ' + evt.data);
 				websocket.close();
-			}
+			};
 		</script>
-
-		<div id="mjpeg-relay" style="width: 350px; height: 225px;"></div>
 	</body>
 </html>


### PR DESCRIPTION
Using a `<canvas>` greatly simplifies the rendering of new stream frames. Flickering didn't occur for me. Additionally the CPU usage is greatly reduced in Firefox and Chrome (from ~10% to ~5%).

Works fine for me in Chrome, Firefox and Safari. According to [caniuse.com](https://caniuse.com/#search=canvas) all browsers should support this, especially considering we are talking about WebSockets here.