### PR TITLE
Add optional framerate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The script is designed to be simple to use with minimal configuration. All video
 
 - **-p \<relay port\>**: Port that the stream will be relayed on (default is 54321)
 - **-w \<WebSocket port\>**: Port that the stream will be relayed on via WebSockets (default is 54322)
+- **-f \<framerate\>**: Limit output framerate (default: unlimited)
 - **-q**: Silence non-essential output
 - **-d**: Turn debugging on
 - **stream-source-url**: URL of the existing MJPEG stream. If the stream is protected with HTTP authentication, supply the credentials via the URL like so: `http://user:password@ip:port/path/to/stream/`

--- a/app/httprequesthandler.py
+++ b/app/httprequesthandler.py
@@ -68,7 +68,7 @@ class HTTPRequestHandler:
 			#explicitly deal with individual requests. Verbose, but more secure
 			if ("/status" in requestPath):
 				clientsock.sendall('HTTP/1.0 200 OK\r\nContentType: text/html\r\n\r\n')
-				clientsock.sendall(self.statusHTML.format(clientcount = self.broadcast.getClientCount(), bwin = float(self.status.bandwidthIn*8)/1000000, bwout = float(self.status.bandwidthOut*8)/1000000))
+				clientsock.sendall(self.statusHTML.format(clientcount = self.broadcast.getClientCount(), bwin = float(self.status.bandwidthIn*8)/1000000, bwout = float(self.status.bandwidthOut*8)/1000000, frin=float(self.status.framerateIn), frout=float(self.status.framerateOut)))
 				clientsock.close()
 			elif ("/style.css" in requestPath):
 				clientsock.sendall('HTTP/1.0 200 OK\r\nContentType: text/html\r\n\r\n')

--- a/app/status.py
+++ b/app/status.py
@@ -7,9 +7,13 @@ class Status:
 	def __init__(self):
 		self.bytesOut = 0
 		self.bytesIn = 0
+		self.framesIn = 0
+		self.framesOut = 0
 
 		self.bandwidthOut = 0
 		self.bandwidthIn = 0
+		self.framerateIn = 0
+		self.framerateOut = 0
 
 		Status._instance = self
 
@@ -19,12 +23,22 @@ class Status:
 	def addToBytesIn(self, byteCount):
 		self.bytesIn += byteCount
 
+	def incFramesIn(self):
+		self.framesIn += 1.0
+
+	def incFramesOut(self):
+		self.framesOut += 1.0
+
 	def run(self):
 		while True:
 			self.bandwidthOut = self.bytesOut / 5
 			self.bandwidthIn = self.bytesIn / 5
+			self.framerateIn = self.framesIn / 5
+			self.framerateOut = self.framesOut / 5
 
 			self.bytesIn = 0
 			self.bytesOut = 0
+			self.framesIn = 0
+			self.framesOut = 0
 
 			time.sleep(5)

--- a/app/status.py
+++ b/app/status.py
@@ -21,10 +21,10 @@ class Status:
 
 	def run(self):
 		while True:
-			self.bandwidthOut = self.bytesOut
-			self.bandwidthIn = self.bytesIn
+			self.bandwidthOut = self.bytesOut / 5
+			self.bandwidthIn = self.bytesIn / 5
 
 			self.bytesIn = 0
 			self.bytesOut = 0
 
-			time.sleep(1)
+			time.sleep(5)

--- a/app/web/status.html
+++ b/app/web/status.html
@@ -19,6 +19,12 @@
 				<tr>
 					<td>Outgoing bandwidth</td><td>{bwout:.4f}Mb/s</td>
 				</tr>
+				<tr>
+					<td>Incoming framerate</td><td>{frin:.1f} fps</td>
+				</tr>
+				<tr>
+					<td>Outgoing framerate</td><td>{frout:.1f} fps</td>
+				</tr>
 			</tbody>
 		</table>
 	</body>

--- a/relay.py
+++ b/relay.py
@@ -36,6 +36,7 @@ if __name__ == '__main__':
 
 	op.add_option("-p", "--port", action="store", default = 54321, dest="port", help = "Port to serve the MJPEG stream on")
 	op.add_option("-w", "--ws-port", action="store", default = 54322, dest="wsport", help = "Port to serve the MJPEG stream on via WebSockets")
+	op.add_option("-f", "--framerate", action="store", default = -1, dest="framerate", help = "Maximum framerate to stream at")
 	op.add_option("-q", "--quiet", action="store_true", default = False, dest="quiet", help = "Silence non-essential output")
 	op.add_option("-d", "--debug", action="store_true", default = False, dest="debug", help = "Turn debugging on")
 
@@ -62,12 +63,19 @@ if __name__ == '__main__':
 		op.print_help()
 		sys.exit(1)
 
+	try:
+		options.framerate = int(options.framerate)
+	except ValueError:
+		logging.error("Framerate must be numeric")
+		op.print_help()
+		sys.exit(1)
+
 	Status()
 	statusThread = threading.Thread(target=Status._instance.run)
 	statusThread.daemon = True
 	statusThread.start()
 
-	broadcaster = Broadcaster(args[0])
+	broadcaster = Broadcaster(args[0], options.framerate)
 	broadcaster.start()
 
 	requestHandler = HTTPRequestHandler(options.port)


### PR DESCRIPTION
This adds an optional `-f` flag to limit framerate. Frames are still obtained from the camera at the same rate, but only sent out to clients if it has been more than `1/fps` seconds since the last frame. The client bandwidth is now recorded from the actual frames sent to clients.

The `/status` page readings are averaged over five seconds.