### PR TITLE
Changes for running as a (background) service

### DIFF
--- a/mjpeg-relay.service
+++ b/mjpeg-relay.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=MJPEG relay
+After=network.target
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=10s
+ExecStart=/home/camera/mjpeg-relay/relay.py
+WorkingDirectory=/home/camera/mjpeg-relay
+User=camera
+Group=camera
+
+[Install]
+WantedBy=multi-user.target
+

--- a/relay.py
+++ b/relay.py
@@ -11,6 +11,7 @@ import re
 import logging
 import requests
 import base64
+import signal
 from app.status import Status
 from app.broadcaster import Broadcaster
 from app.httprequesthandler import HTTPRequestHandler
@@ -32,6 +33,10 @@ def quit():
 	quitsock.connect(("127.0.0.1", options.port))
 	quitsock.close()
 	sys.exit(1)
+
+def handle_signal(sig, frame):
+	logging.info("Received signal, shutting down..")
+	quit()
 
 if __name__ == '__main__':
 	op = OptionParser(usage = "%prog [options] stream-source-url")
@@ -80,15 +85,11 @@ if __name__ == '__main__':
 	webSocketHandlerThread.daemon = True
 	webSocketHandlerThread.start()
 
-	try:
-		while raw_input() != "quit":
-			continue
-		quit()
-	except KeyboardInterrupt:
-		quit()
-	except EOFError:
-		#this exception is raised when ctrl-c is used to close the application on Windows, appears to be thrown twice?
-		try:
-			quit()
-		except KeyboardInterrupt:
-			os._exit(0)
+	# Start signal handlers
+	signal.signal(signal.SIGHUP, handle_signal)
+	signal.signal(signal.SIGINT, handle_signal)
+	signal.signal(signal.SIGQUIT, handle_signal)
+	signal.signal(signal.SIGTERM, handle_signal)
+
+	while True:
+		signal.pause()

--- a/relay.py
+++ b/relay.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2.7
+
 import sys
 import socket
 import threading


### PR DESCRIPTION
By default, `relay.py` will wait for user input by reading from the terminal. 
This breaks catastrophically when the process is not attached to a terminal, e.g. when started as a systemd unit (#17).

I've changed `relay.py` so that it waits for signals. This works both for keyboard events as well as detached from a terminal. Additionally, a sample systemd unit is provided.